### PR TITLE
Clarify Dataset.groupByKey paragraph.

### DIFF
--- a/04_rdd_actions_and_transformations_by_example.md
+++ b/04_rdd_actions_and_transformations_by_example.md
@@ -123,7 +123,7 @@ It is worth noting that functions like `collect_list` or `collect_set` don't use
 
 #### Dataset.groupByKey
 
-Excluding certain `Dataset` specific optimizations `groupByKey` is comparable to it's RDD counterpart but, similarly to PySpark `RDD.groupByKey`, exposes grouped data as a lazy data structure and can be preferable when expected number of values per key is large.
+Excluding certain `Dataset` specific optimizations `groupByKey` with `mapGroups` / `flatMapGroups` is comparable to it's RDD counterpart but, similarly to PySpark `RDD.groupByKey`, exposes grouped data as a lazy data structure and can be preferable when expected number of values per key is large.
 
 ### When to Use groupByKey and When to Avoid It
 


### PR DESCRIPTION
We should distinguish between `mapGroups` / `flatMapGroups` and `reduceGroups`.